### PR TITLE
Scheduled canceling of expired reservations

### DIFF
--- a/src/main/java/com/example/libraryapi/LibraryApiApplication.java
+++ b/src/main/java/com/example/libraryapi/LibraryApiApplication.java
@@ -2,7 +2,9 @@ package com.example.libraryapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class LibraryApiApplication {
 

--- a/src/main/java/com/example/libraryapi/repository/ReservationRepository.java
+++ b/src/main/java/com/example/libraryapi/repository/ReservationRepository.java
@@ -2,11 +2,13 @@ package com.example.libraryapi.repository;
 
 import com.example.libraryapi.model.Reservation;
 import com.example.libraryapi.model.ReservationItem;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
     Page<Reservation> findByClient_EmailAddressAndBorrowed(String emailAddress, boolean borrowed, Pageable paging);
@@ -14,4 +16,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, UUID> 
     List<Reservation> findByReservationItemsIn(List<ReservationItem> toList);
 
     Page<Reservation> findByCanceledFalseAndBorrowedFalse(Pageable paging);
+
+    @Query("""
+                SELECT r
+                FROM Reservation r
+                LEFT JOIN FETCH r.reservationItems
+                WHERE r.canceled = false
+                AND r.borrowed = false
+                AND r.endOfReservation < ?1""")
+    List<Reservation> findExpiredReservations(LocalDate today);
 }

--- a/src/main/java/com/example/libraryapi/service/ScheduledTaskService.java
+++ b/src/main/java/com/example/libraryapi/service/ScheduledTaskService.java
@@ -1,0 +1,48 @@
+package com.example.libraryapi.service;
+
+import com.example.libraryapi.model.Reservation;
+import com.example.libraryapi.repository.ReservationItemRepository;
+import com.example.libraryapi.repository.ReservationRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledTaskService {
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationItemRepository reservationItemRepository;
+
+    @Caching(
+            evict = {
+                    @CacheEvict(value = "books_cache", allEntries = true),
+                    @CacheEvict(value = "book_cache", allEntries = true),
+                    @CacheEvict(value = "books_by_category_cache", allEntries = true),
+                    @CacheEvict(value = "books_by_phrase_cache", allEntries = true),
+                    @CacheEvict(value = "reservation_items_cache", allEntries = true),
+                    @CacheEvict(value = "reservation_item_by_client_cache", allEntries = true),
+            }
+    )
+    @Scheduled(cron = "${com.scheduled.cron}")
+    public void deleteExpiredReservations() {
+        LocalDate today = LocalDate.now();
+        System.out.println("Today: " + today);
+        List<Reservation> expiredReservations = reservationRepository.findExpiredReservations(today);
+        expiredReservations.forEach(this::deleteReservation);
+    }
+    @Transactional
+    public void deleteReservation(Reservation reservation) {
+        reservation.setCanceled(true);
+        reservationRepository.save(reservation);
+        (reservation.getReservationItems()).forEach(reservationItem -> {
+            reservationItem.setReturned(true);
+            reservationItemRepository.save(reservationItem);
+        });
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.jpa.show-sql=true
 logging.level.org.springframework.data.repository.query=TRACE
 
 spring.security.oauth2.resource-server.jwt.issuer-uri=https://library-login.us.auth0.com
-com.scheduled.cron= 0 0 3 * * *
+com.scheduled.cron= 0 0 3 * * 2-6

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.jpa.show-sql=true
 logging.level.org.springframework.data.repository.query=TRACE
 
 spring.security.oauth2.resource-server.jwt.issuer-uri=https://library-login.us.auth0.com
+com.scheduled.cron= 0 0 3 * * *


### PR DESCRIPTION
This PR contains a new service for managing scheduled tasks related to the Reservation and ReservationItem entities.
The service includes a scheduled job that runs once a day at 3 am from Tuesday to Saturday.
Canceling operations are marked as transactional individually, preventing the entire job from rolling back in case of errors.